### PR TITLE
More bug fixes and additions

### DIFF
--- a/README
+++ b/README
@@ -5,6 +5,7 @@ On Ubuntu at least, you will need the following packages;
    - llvm
    - llvm-dev
    - uuid-dev
+   - libssl-dev
    - libblocksruntime-dev
    - libc6-i386-dev (if 64-bit)
    - gcc-multilib (if 64-bit)

--- a/bootstrap_cmds-60/migcom.tproj/Makefile
+++ b/bootstrap_cmds-60/migcom.tproj/Makefile
@@ -3,6 +3,10 @@ ifeq ($(HOST_CPU),i386)
 	CPPFLAGS = -D__i386__ -DI386 -D__LITTLE_ENDIAN__
 	CFLAGS = -m32 -O2
 endif
+ifeq ($(HOST_CPU),i686)
+	CPPFLAGS = -D__i386__ -DI386 -D__LITTLE_ENDIAN__
+	CFLAGS = -m32 -O2
+endif
 ifeq ($(HOST_CPU),x86_64)
 	CPPFLAGS = -D__i386__ -DI386 -D__LITTLE_ENDIAN__
 	CFLAGS = -m32 -O2
@@ -18,6 +22,10 @@ endif
 ifeq ($(HOST_CPU),powerpc)
 	CPPFLAGS = -D__ppc__ -DPOWERPC -D__LITTLE_ENDIAN__
 	CFLAGS = -O2
+endif
+ifeq ($(HOST_CPU),unknown)
+	@echo "ERROR: Unknown host cpu type!"
+	exit 1
 endif
 
 TARGET = migcom

--- a/cctools-836/include/foreign/arm/_types.h
+++ b/cctools-836/include/foreign/arm/_types.h
@@ -9,6 +9,7 @@
  * flotaing point and other arithmetic types, as needed, later.
  */
 
+#if !defined(__linux__)
 #ifdef __GNUC__
 typedef __signed char		__int8_t;
 #else	/* !__GNUC__ */
@@ -21,6 +22,9 @@ typedef int			__int32_t;
 typedef unsigned int		__uint32_t;
 typedef long long		__int64_t;
 typedef unsigned long long	__uint64_t;
+#else /* We are on linux, use native types */
+#include <bits/types.h>
+#endif
 
 typedef long			__darwin_intptr_t;
 typedef unsigned int		__darwin_natural_t;

--- a/cctools-836/include/foreign/i386/_types.h
+++ b/cctools-836/include/foreign/i386/_types.h
@@ -33,6 +33,7 @@
  * flotaing point and other arithmetic types, as needed, later.
  */
 
+#if !defined(__linux__)
 #ifdef __GNUC__
 typedef __signed char		__int8_t;
 #else	/* !__GNUC__ */
@@ -45,6 +46,9 @@ typedef int			__int32_t;
 typedef unsigned int		__uint32_t;
 typedef long int		__int64_t;
 typedef unsigned long int	__uint64_t;
+#else /* We are on linux, use native types */
+#include <bits/types.h>
+#endif
 
 typedef long			__darwin_intptr_t;
 typedef unsigned int		__darwin_natural_t;

--- a/cctools-836/include/foreign/ppc/_types.h
+++ b/cctools-836/include/foreign/ppc/_types.h
@@ -33,6 +33,7 @@
  * flotaing point and other arithmetic types, as needed, later.
  */
 
+#if !defined(__linux__)
 #ifdef __GNUC__
 typedef __signed char		__int8_t;
 #else	/* !__GNUC__ */
@@ -45,6 +46,9 @@ typedef int			__int32_t;
 typedef unsigned int		__uint32_t;
 typedef long long		__int64_t;
 typedef unsigned long long	__uint64_t;
+#else /* We are on linux, use native types */
+#include <bits/types.h>
+#endif
 
 typedef long			__darwin_intptr_t;
 typedef unsigned int		__darwin_natural_t;


### PR DESCRIPTION
- Added i686 support to migcom build (older 32-bit linux distros report as i386, newer ones as i686)
- Have migcom build throw error for unknown cpu type
- Use native size types for cctools (to avoid clashes with linux and darwin headers)
- Added libssl-dev as build prerequisite (cctools apparently needs this for md5-related things)
