### PR TITLE
Have mig find mktemp to avoid path issues

### DIFF
--- a/bootstrap_cmds-60/migcom.tproj/mig.sh
+++ b/bootstrap_cmds-60/migcom.tproj/mig.sh
@@ -88,7 +88,7 @@ cppflags="-D__MACH30__"
 files=
 arch=`/usr/bin/arch`
 
-WORKTMP=`/usr/bin/mktemp -d "${TMPDIR:-/tmp}/mig.XXXXXX"`
+WORKTMP=`/bin/mktemp -d "${TMPDIR:-/tmp}/mig.XXXXXX"`
 if [ $? -ne 0 ]; then
       echo "Failure creating temporary work directory: ${WORKTMP}"
       echo "Exiting..."

--- a/bootstrap_cmds-60/migcom.tproj/mig.sh
+++ b/bootstrap_cmds-60/migcom.tproj/mig.sh
@@ -88,7 +88,9 @@ cppflags="-D__MACH30__"
 files=
 arch=`/usr/bin/arch`
 
-WORKTMP=`/bin/mktemp -d "${TMPDIR:-/tmp}/mig.XXXXXX"`
+MKTEMP=`which mktemp`
+
+WORKTMP=`${MKTEMP} -d "${TMPDIR:-/tmp}/mig.XXXXXX"`
 if [ $? -ne 0 ]; then
       echo "Failure creating temporary work directory: ${WORKTMP}"
       echo "Exiting..."


### PR DESCRIPTION
- On some linux distros, mktemp is located in /bin, use the 'which' command to find the absolute path of mktemp.
