### PR TITLE
Add tcsh to list of requirements

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,7 @@ On Ubuntu at least, you will need the following packages;
    - gcc-multilib (if 64-bit)
    - build-essential
    - flex
+   - tcsh
    - bison
    - clang
    - all of the autotools


### PR DESCRIPTION
- Add tcsh to list of requirements, so people don't run into issues with doconf if their distribution doesn't have it already installed.
